### PR TITLE
fix: typos in documentation files

### DIFF
--- a/documentation/src/crates/primitives.md
+++ b/documentation/src/crates/primitives.md
@@ -15,7 +15,7 @@ It is set up to be compatible with environments that do not include Rust's stand
 - [specification](./primitives/specifications.md): This module defines types related to Ethereum specifications (also known as hard forks).
 - [state](./primitives/state.md): This module provides types and functions for managing Ethereum state, including accounts and storage.
 - [utilities](./primitives/utils.md): This module provides utility functions used in multiple places across the EVM implementation.
-- [kzg](./primitives/kzg.md): This module provides types and functions related to KZG commitment, it is empolyed visibly in the Point Evalution Precompile.
+- [kzg](./primitives/kzg.md): This module provides types and functions related to KZG commitment, it is employed visibly in the Point Evaluation Precompile.
 
 ### External Crates:
 

--- a/documentation/src/crates/primitives/kzg.md
+++ b/documentation/src/crates/primitives/kzg.md
@@ -1,12 +1,12 @@
 # KZG 
 
-With the introduction of [EIP4844](https://eips.ethereum.org/EIPS/eip-4844), this use of blobs for a more efficent short term storage is employed, the validity of this blob stored in the consensus layer is verified using the `Point Evaluation` pre-compile, a fancy way of verifing that and evaluation at a given point of a commited polynomial is vaild, in a much more bigger scale, implies that `Data is Available`.
+With the introduction of [EIP4844](https://eips.ethereum.org/EIPS/eip-4844), this use of blobs for a more efficient short term storage is employed, the validity of this blob stored in the consensus layer is verified using the `Point Evaluation` pre-compile, a fancy way of verifying that and evaluation at a given point of a committed polynomial is valid, in a much more bigger scale, implies that `Data is Available`.
 
 This module houses;
 
 1. `KzgSettings`: Stores the setup and parameters needed for computing and verify KZG proofs.
 
-    The `KZG` premitive provides a default `KZGSettings` obtained from [this]( https://ceremony.ethereum.org/) trusted setup ceremony, a provision is also made for using a custom `KZGSettings` if need be, this is available in the `env.cfg`.
+    The `KZG` primitive provides a default `KZGSettings` obtained from [this]( https://ceremony.ethereum.org/) trusted setup ceremony, a provision is also made for using a custom `KZGSettings` if need be, this is available in the `env.cfg`.
 
 
 2. `trusted_setup_points`: This module contains functions and types used for parsing and utilizing the [Trusted Setup]( https://ceremony.ethereum.org/) for the `KzgSettings`.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `empolyed` to `employed`
Corrected `Evalution` to `Evaluation`
Corrected `efficent` to `efficient`
Corrected `verifing` to `verifying`
Corrected `commited` to `committed`
Corrected `vaild` to `valid`
Corrected `premitive` to `primitive`
Corrected `commited` to `committed`

Please review the changes and let me know if any additional changes are needed.